### PR TITLE
Fix theme to AppCompat

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.PassKeyTest" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.PassKeyTest" parent="Theme.AppCompat.DayNight.NoActionBar" />
 </resources>


### PR DESCRIPTION
## Summary
- fix crash requiring AppCompat theme by changing the app theme to inherit from `Theme.AppCompat.DayNight.NoActionBar`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6877e9ff0aec832cad7bf46c334474ae