### PR TITLE
Fix CredentialManager API usage

### DIFF
--- a/app/src/main/java/nick/bonson/passkeytest/MainActivity.kt
+++ b/app/src/main/java/nick/bonson/passkeytest/MainActivity.kt
@@ -83,7 +83,7 @@ class MainActivity : AppCompatActivity() {
     private fun registerPasskey() {
         lifecycleScope.launch {
             val request = CreatePublicKeyCredentialRequest("register_challenge")
-            credentialManager.createCredentialAsync(this@MainActivity, request)
+            credentialManager.createCredential(this@MainActivity, request)
             passkeyService.register()
         }
     }
@@ -92,7 +92,7 @@ class MainActivity : AppCompatActivity() {
         lifecycleScope.launch {
             val option = GetPublicKeyCredentialOption("login_challenge")
             val request = GetCredentialRequest(listOf(option))
-            credentialManager.getCredentialAsync(this@MainActivity, request)
+            credentialManager.getCredential(this@MainActivity, request)
             passkeyService.login()
         }
     }


### PR DESCRIPTION
## Summary
- fix passkey registration and login calls by using the suspend `createCredential` and `getCredential` APIs

## Testing
- No tests run due to user instruction

------
https://chatgpt.com/codex/tasks/task_e_6877ffded364832c9bba319f80ea56e6