### PR TITLE
Add Play Services provider for CredentialManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This project demonstrates a simple implementation of passkeys on Android and iOS
 ## Android
 - Uses Retrofit and OkHttp for networking.
 - Passkey support via `CredentialManager` from the `androidx.credentials` library.
+- Requires the Play Services auth provider dependency `androidx.credentials:play-services-auth`.
 - Layout uses ViewBinding.
 
 ## iOS

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     implementation(libs.okhttp)
     implementation(libs.okhttp.logging.interceptor)
     implementation(libs.androidx.credentials)
+    implementation(libs.androidx.credentials.play.services.auth)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ retrofit = "2.9.0"
 okhttp = "4.12.0"
 appcompat = "1.6.1"
 credentials = "1.3.0"
+credentialsPlayServicesAuth = "1.3.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -23,6 +24,7 @@ okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhtt
 okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 androidx-credentials = { group = "androidx.credentials", name = "credentials", version.ref = "credentials" }
+androidx-credentials-play-services-auth = { group = "androidx.credentials", name = "play-services-auth", version.ref = "credentialsPlayServicesAuth" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- include Play Services auth provider dependency
- note the dependency in README

## Testing
- No tests run due to user request

------
https://chatgpt.com/codex/tasks/task_e_6878057af4a8832ca185f87db682b2f7